### PR TITLE
bugfix: mailbox delete logic

### DIFF
--- a/server/app/serverapp.js
+++ b/server/app/serverapp.js
@@ -100,7 +100,7 @@ app.get('*.*', express.static(path.join(DIST_FOLDER, "browser")));
       });
     });
 
-    db.collection('mailboxes').remove({'emails': {$exists: true, $ne: '[]'}}, function (err, result) {
+    db.collection('mailboxes').remove({'emails': {$exists: true, $eq: []}}, function (err, result) {
       if (err) {
         logger.error(err);
       } else {


### PR DESCRIPTION
All mailboxes were getting deleted because the predicate always evaluated to true. Now only mailboxes with the `emails` array equal to `[]` get deleted.