### PR TITLE
bugfix - validateAddress always returns true

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,3 +10,4 @@ allowedDomains=my.domain.com
 jwtSecret=AH3M 709 S3cR3T
 jwtExpiresIn=3600
 maxAllowedApiCalls=1000
+webHookUrl=

--- a/ahem.js
+++ b/ahem.js
@@ -9,7 +9,7 @@ const path = require('path');
 const mongo = require('mongodb');
 const assert = require('assert');
 const http = require('http');
-require('dotenv').config()
+require('dotenv').config();
 const properties = {
   serverBaseUri: process.env.serverBaseUri,
   mongoConnectUrl: process.env.mongoConnectUrl,
@@ -22,7 +22,8 @@ const properties = {
   allowedDomains: process.env.allowedDomains.split(','),
   jwtSecret: process.env.jwtSecret,
   jwtExpiresIn: parseInt(process.env.jwtExpiresIn) || 3600,
-  maxAllowedApiCalls: parseInt(process.env.maxAllowedApiCalls) || 10000
+  maxAllowedApiCalls: parseInt(process.env.maxAllowedApiCalls) || 10000,
+  webHookUrl: process.env.webHookUrl
 };
 
 logger.info('connecting to db', properties.mongoConnectUrl);

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/socket.io": "^2.1.4",
     "angular-swagger-ui": "^0.5.5",
     "angulartics2": "^7.5.2",
+    "axios": "^0.20.0",
     "core-js": "^2.6.11",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/server/app/smtp.js
+++ b/server/app/smtp.js
@@ -115,7 +115,7 @@ function startSTMPServer(properties, db, io) {
 function validateAddress(address, allowedDomains) {
   // return true always if: a) allowedDomains is empty or b) null or c) properties.json only has my.domain.com
   if (!allowedDomains ||
-    (allowedDomains && allowedDomains.length ||
+    (allowedDomains && !allowedDomains.length ||
       (allowedDomains && allowedDomains.length === 1 && allowedDomains[0] === 'my.domain.com')
     )) {
     return true;


### PR DESCRIPTION
A missing negation caused `validateAddress` to incorrectly return true when `allowedDomains` exists and has elements. In fact, when `allowedDomains` exists and has elements the function should continue to compare the email address to the domains instead of bailing out early with a response of true.