### PR TITLE
feat: add useEnvelopeRecipients option for correct mailbox routing of forwarded mail

### DIFF
--- a/properties.json
+++ b/properties.json
@@ -8,6 +8,7 @@
   "emailDeleteAge" : 86400,
   "allowAutocomplete" : true,
   "allowedDomains" : ["my.domain.com"],
+  "useEnvelopeRecipients": false,
   "jwtSecret": "AH3M 709 S3cR3T",
   "jwtExpiresIn": 3600,
   "maxAllowedApiCalls": 1000

--- a/server/app/smtp.js
+++ b/server/app/smtp.js
@@ -55,6 +55,13 @@ function startSTMPServer(properties, db, io) {
             }
           });
 
+          // Persist SMTP envelope recipients on the email document.
+          // These are the authoritative delivery targets from the SMTP
+          // RCPT TO commands, which may differ from the To: header
+          // (e.g. when mail is auto-forwarded).
+          const envelopeRecipients = session.envelope.rcptTo || [];
+          mail.envelopeTo = envelopeRecipients.map(r => r.address);
+
           db.collection('emails').insertOne(mail, function (err1, result) {
             if (err1) {
               logger.error('Error in writing email to db!', err1);
@@ -76,7 +83,23 @@ function startSTMPServer(properties, db, io) {
               io.emit('emailCount', result.value);
             });
             try {
-              mail.to.value.forEach(recipient => {
+              // Determine which recipients to use for mailbox routing.
+              //
+              // Default (useEnvelopeRecipients: false / unset):
+              //   Use the parsed To: header — the original behavior.
+              //
+              // useEnvelopeRecipients: true:
+              //   Use the SMTP envelope RCPT TO addresses instead. This is
+              //   needed when AHEM receives forwarded mail (e.g. Gmail
+              //   auto-forward), where the To: header retains the original
+              //   recipient but RCPT TO contains the actual forwarding
+              //   destination. Without this flag, forwarded emails are stored
+              //   in MongoDB but never appear in the target mailbox.
+              const recipients = properties.useEnvelopeRecipients
+                ? envelopeRecipients
+                : (mail.to && mail.to.value ? mail.to.value : []);
+
+              recipients.forEach(recipient => {
                 const nameAndDomain = recipient.address.split('@');
                 if (properties.allowedDomains.indexOf(nameAndDomain[1].toLowerCase()) > -1) {
                   db.collection('mailboxes').updateOne({'name': nameAndDomain[0].toLowerCase()}, {
@@ -101,7 +124,6 @@ function startSTMPServer(properties, db, io) {
             } catch (e) {
               logger.error(e);
             }
-            ;
           });
         });
         return callback();


### PR DESCRIPTION
## Problem

When AHEM receives **forwarded email** (e.g. via Gmail auto-forward, or any MTA-level forwarding rule), the email is accepted and stored in MongoDB but **never appears in the target mailbox**.

This happens because mailbox routing in `smtp.js` uses the parsed `To:` message header to determine which mailbox an email belongs to. For forwarded mail, the `To:` header retains the **original recipient** (e.g. `user@gmail.com`), not the forwarding destination (e.g. `catch-all-box@ahem-domain.com`). Since the original recipient's domain doesn't match `allowedDomains`, the email is never added to any mailbox — it becomes orphaned in the `emails` collection.

### How SMTP forwarding works

```
Original sender → recipient@gmail.com       (To: header = recipient@gmail.com)
Gmail auto-forward → catch-all@ahem.com     (SMTP RCPT TO = catch-all@ahem.com)
```

The SMTP envelope `RCPT TO` is the authoritative indicator of where the mail should be delivered. The `To:` header is a display-level field from the original message and is not rewritten by forwarding MTAs.

### Current behavior

| Signal | Value | Used for routing? |
|--------|-------|-------------------|
| `To:` header | `recipient@gmail.com` | **Yes** (current) |
| SMTP `RCPT TO` | `catch-all@ahem.com` | No |
| `session.envelope.rcptTo` | Available in `onData` | Ignored |

Since `gmail.com` ∉ `allowedDomains`, the email is stored but never assigned to a mailbox.

### Affected use cases

- **Gmail auto-forwarding** to an AHEM catch-all address
- **Server-side forwarding rules** (e.g. Postfix `virtual_alias_maps`, Exchange transport rules)
- **Any MTA relay** that preserves original headers while rewriting the envelope

This does **not** affect direct sends or manual forwards (where the user composes a new message), since those produce a fresh `To:` header matching the AHEM domain.

## Solution

This PR adds an opt-in `useEnvelopeRecipients` flag to `properties.json` (default: `false`):

- **`false` (default):** Existing behavior — mailbox routing uses the `To:` header. No change for current deployments.
- **`true`:** Mailbox routing uses `session.envelope.rcptTo` from the SMTP session instead, which correctly identifies the forwarding destination.

Additionally, regardless of the flag, the SMTP envelope recipients are now always persisted on the stored email document as `envelopeTo`. This gives API consumers access to the authoritative SMTP delivery targets without changing the routing behavior.

### Changes

| File | Change |
|------|--------|
| `server/app/smtp.js` | Read `session.envelope.rcptTo`; use it for mailbox routing when flag is set; always persist as `mail.envelopeTo` |
| `properties.json` | Add `useEnvelopeRecipients: false` |

### Example configuration

```json
{
  "allowedDomains": ["ahem.example.com"],
  "useEnvelopeRecipients": true
}
```

With this configuration, an email forwarded to `inbox@ahem.example.com` will appear in the `inbox` mailbox — even if the `To:` header says `someone@otherdomain.com`.

## Backward compatibility

- Default is `false` — **zero behavioral change** for existing deployments.
- The `envelopeTo` field is additive; existing email documents and API responses are unaffected.
- No API changes required.

---
Fixes #93