### PR TITLE
fix: envelope recipients race condition and dotenv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,30 @@ emailDeleteAge | The age in seconds above which emails will be deleted.
 allowedDomains | An array of allowed email domains. These domains will be allowed by the server as RCPT TO: entries. This also makes the server not act as an open relay. Format: ["my.domain.com", "my.second-domain.com"].
 customText | HTML string that will replace the default text in the landing page.
 allowAutocomplete | If set to false, will prevent auto completing users in the ui.
+useEnvelopeRecipients | When set to `true`, mailbox routing uses the SMTP envelope `RCPT TO` address instead of the parsed `To:` header. This is required when AHEM receives **forwarded email** (e.g. Gmail auto-forward, Postfix aliases, Exchange transport rules), where the `To:` header retains the original recipient but the SMTP envelope contains the actual forwarding destination. Default: `false`. See [Email Forwarding](#email-forwarding) below.
 jwtSecret | The JWT secret, if using token authentication.
 jwtExpiresIn | JWT token TTL in seconds. -1 means token validation is not enforced.
 maxAllowedApiCalls | If using token validation, this is the amount of API calls a token is allowed to make.
+
+### Email Forwarding
+
+When email is forwarded to AHEM (e.g. via Gmail auto-forwarding), the `To:` header still contains the **original** recipient address, not the AHEM mailbox address. By default, AHEM uses the `To:` header for mailbox routing, which means forwarded emails may not appear in any mailbox if the original domain isn't in `allowedDomains`.
+
+To fix this, set `useEnvelopeRecipients=true` in your `.env` or environment variables. This tells AHEM to route emails based on the SMTP `RCPT TO` envelope address — which is the authoritative delivery target set by the forwarding MTA.
+
+**Example scenario:**
+
+```
+Original:  Adobe sends email to user@gmail.com        (To: header = user@gmail.com)
+Forwarded: Gmail auto-forwards to inbox@mail.ahem.com (SMTP RCPT TO = inbox@mail.ahem.com)
+```
+
+| Setting | Routing uses | Result |
+|---------|-------------|--------|
+| `useEnvelopeRecipients=false` (default) | `To:` header → `user@gmail.com` | Email stored but **not routed** to any mailbox (domain mismatch) |
+| `useEnvelopeRecipients=true` | SMTP envelope → `inbox@mail.ahem.com` | Email appears in `inbox` mailbox |
+
+Regardless of this setting, the SMTP envelope recipients are always persisted on the email document as `envelopeTo`, giving API consumers access to the authoritative delivery targets.
 
 ### Docker
 * Build docker: docker build -t o4oren/ahem .

--- a/ahem.js
+++ b/ahem.js
@@ -23,7 +23,8 @@ const properties = {
   jwtSecret: process.env.jwtSecret,
   jwtExpiresIn: parseInt(process.env.jwtExpiresIn) || 3600,
   maxAllowedApiCalls: parseInt(process.env.maxAllowedApiCalls) || 10000,
-  webHookUrl: process.env.webHookUrl
+  webHookUrl: process.env.webHookUrl,
+  useEnvelopeRecipients: process.env.useEnvelopeRecipients === 'true'
 };
 
 logger.info('connecting to db', properties.mongoConnectUrl);

--- a/server/app/api.js
+++ b/server/app/api.js
@@ -29,7 +29,8 @@ router.get('/properties', (req, res, next) => {
     emailDeleteAge: req.properties.emailDeleteAge,
     allowedDomains: req.properties.allowedDomains,
     customText: req.properties.customText,
-    allowAutocomplete: req.properties.allowAutocomplete
+    allowAutocomplete: req.properties.allowAutocomplete,
+    useEnvelopeRecipients: req.properties.useEnvelopeRecipients
   });
 });
 

--- a/server/app/smtp.js
+++ b/server/app/smtp.js
@@ -43,6 +43,10 @@ function startSTMPServer(properties, db, io) {
 
       stream.on('end', function () {
         logger.info('SMTP DATA end');
+        // Capture envelope recipients eagerly — once callback() is called
+        // (below), smtp-server may reset the session envelope before the
+        // async simpleParser callback fires.
+        const envelopeRecipients = (session.envelope.rcptTo || []).map(r => r.address);
         simpleParser(mailDataString, (err, mail) => {
           mail.timestamp = new Date().getTime();
 
@@ -55,12 +59,8 @@ function startSTMPServer(properties, db, io) {
             }
           });
 
-          // Persist SMTP envelope recipients on the email document.
-          // These are the authoritative delivery targets from the SMTP
-          // RCPT TO commands, which may differ from the To: header
-          // (e.g. when mail is auto-forwarded).
-          const envelopeRecipients = session.envelope.rcptTo || [];
-          mail.envelopeTo = envelopeRecipients.map(r => r.address);
+          // Persist SMTP envelope recipients (captured eagerly above).
+          mail.envelopeTo = envelopeRecipients;
 
           db.collection('emails').insertOne(mail, function (err1, result) {
             if (err1) {
@@ -96,7 +96,7 @@ function startSTMPServer(properties, db, io) {
               //   destination. Without this flag, forwarded emails are stored
               //   in MongoDB but never appear in the target mailbox.
               const recipients = properties.useEnvelopeRecipients
-                ? envelopeRecipients
+                ? envelopeRecipients.map(addr => ({ address: addr }))
                 : (mail.to && mail.to.value ? mail.to.value : []);
 
               recipients.forEach(recipient => {


### PR DESCRIPTION
## Problem

PR #92 introduced `useEnvelopeRecipients` and `envelopeTo` persistence, but two bugs prevent them from working:

### 1. Race condition: `envelopeTo` is always `[]`

In `smtp.js`, `session.envelope.rcptTo` is read inside the async `simpleParser` callback (line 62). However, `callback()` is called **synchronously** when the stream ends (line 129), signaling smtp-server that the DATA command is complete. smtp-server then resets `session.envelope` before `simpleParser` finishes parsing — so `session.envelope.rcptTo` is always empty by the time it's read.

**Fix:** Capture `session.envelope.rcptTo` eagerly at stream end, before `simpleParser` runs.

### 2. `useEnvelopeRecipients` not read from dotenv config

`ahem.js` builds the `properties` object from `process.env` (lines 13–27) but never includes `useEnvelopeRecipients`. Even with `useEnvelopeRecipients=true` in `.env`, `properties.useEnvelopeRecipients` is always `undefined`, so mailbox routing always falls back to the `To:` header.

**Fix:** Add `useEnvelopeRecipients: process.env.useEnvelopeRecipients === 'true'` to the properties object.

### 3. Properties API doesn't expose `useEnvelopeRecipients`

The `GET /api/properties` endpoint omits `useEnvelopeRecipients`, making it hard to verify the configuration.

**Fix:** Include it in the response.

## Changes

| File | Change |
|------|--------|
| `server/app/smtp.js` | Capture `session.envelope.rcptTo` before async `simpleParser` callback |
| `ahem.js` | Read `useEnvelopeRecipients` from env |
| `server/app/api.js` | Expose `useEnvelopeRecipients` in properties API |

## Testing

Verified with Gmail auto-forwarding to an AHEM instance:
- **Before:** `envelopeTo: []`, forwarded emails not routed to mailbox
- **After:** `envelopeTo: ["recipient@mail.domain.com"]`, emails correctly appear in mailbox

Follows up on #92.